### PR TITLE
HourlyWind

### DIFF
--- a/ClimsoftVer4/ClimsoftVer4/frmNewHourlyWind.vb
+++ b/ClimsoftVer4/ClimsoftVer4/frmNewHourlyWind.vb
@@ -204,8 +204,8 @@
             Return False
         End If
 
-        'check total if its required
-        If Not ucrHourlyWind.checkTotal() Then
+        'check speed total required
+        If Not ucrHourlyWind.checkSpeedTotal() Then
             Return False
         End If
 

--- a/ClimsoftVer4/ClimsoftVer4/frmNewHourlyWind.vb
+++ b/ClimsoftVer4/ClimsoftVer4/frmNewHourlyWind.vb
@@ -1,5 +1,7 @@
 ﻿Public Class frmNewHourlyWind
     Private bFirstLoad As Boolean = True
+    Dim iDirectionDigits As Integer
+    Dim iSpeedDigits As Integer
 
     Private Sub frmNewHourlyWind_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         If bFirstLoad Then
@@ -11,8 +13,14 @@
     Private Sub InitaliseDialog()
         ucrDay.setYearAndMonthLink(ucrYearSelector, ucrMonth)
 
-        ucrHourlyWind.SetSpeedDigits(Val(txtSpeedDigits.Text))
-        ucrHourlyWind.SetDirectionDigits(Val(txtDirectionDigits.Text))
+        'get default database direction and speed digits, then set them to the controls
+        SetDirectionAndSpeedDigits()
+        txtDirectionDigits.Text = iDirectionDigits
+        txtSpeedDigits.Text = iSpeedDigits
+
+        ucrHourlyWind.SetDirectionDigits(iDirectionDigits)
+        ucrHourlyWind.SetSpeedDigits(iSpeedDigits)
+
         ucrHourlyWind.SetDirectionValidation(112)
         ucrHourlyWind.SetSpeedValidation(111)
 
@@ -109,18 +117,9 @@
     End Sub
 
     Private Sub btnClear_Click(sender As Object, e As EventArgs) Handles btnClear.Click
-        'SAMUEL IS DOING THIS AND I'M NOT SURE WHY BUT I DID IT TO HAVE
-        'A SIMILAR IMPLEMENTATION, THE CHECKING OF HEADER INFORMATION
-        'COULD BE REMOVED IF ITS NOT NECESSARY
-        'Check if header information is complete. If the header information is complete and there is at least on obs value then,
-        'carry out the next actions, otherwise bring up message showing that there is insufficient data
-        'If (Not ucrHourlyWind.IsDirectionValuesEmpty) AndAlso Strings.Len(ucrStationSelector.GetValue) > 0 AndAlso Strings.Len(ucrYearSelector.GetValue) > 0 AndAlso Strings.Len(ucrMonth.GetValue) AndAlso Strings.Len(ucrDay.GetValue) > 0 Then
         ucrNavigation.ResetControls()
         ucrNavigation.MoveFirst()
         SaveEnable()
-        'Else
-        'MessageBox.Show("Incomplete header information and insufficient observation data!", "Clear Record", MessageBoxButtons.OK, MessageBoxIcon.Information)
-        'End If
     End Sub
 
     'This is from Samuel's code
@@ -194,13 +193,8 @@
             Return False
         End If
 
-        'Then Do QC Checks. 
-        'based on upper & lower limit for wind direction 
-        If Not ucrHourlyWind.CheckQcForDirection() Then
-            Return False
-        End If
-        'based on upper & lower limit for wind speed 
-        If Not ucrHourlyWind.CheckQcForSpeed() Then
+        'check if values are valid.  
+        If Not ucrHourlyWind.IsValuesValid() Then
             Return False
         End If
 

--- a/ClimsoftVer4/ClimsoftVer4/frmNewHourlyWind.vb
+++ b/ClimsoftVer4/ClimsoftVer4/frmNewHourlyWind.vb
@@ -212,4 +212,32 @@
         Return True
     End Function
 
+    ''' <summary>
+    ''' This sets the direction and speed digits from the database 
+    ''' by getting the values from the regkeys database table
+    ''' </summary>
+    Private Sub SetDirectionAndSpeedDigits()
+        Try
+            Dim clsDataDefinition As DataCall
+            Dim dtbl As DataTable
+            Dim row As DataRow
+
+            clsDataDefinition = New DataCall
+            clsDataDefinition.SetTableName("regkeys")
+            clsDataDefinition.SetFields(New List(Of String)({"keyName", "keyValue"}))
+            dtbl = clsDataDefinition.GetDataTable()
+            If dtbl IsNot Nothing AndAlso dtbl.Rows.Count > 0 Then
+                'get direction digits
+                row = dtbl.Select("keyName = 'key05'").FirstOrDefault()
+                iDirectionDigits = If(row IsNot Nothing, Integer.Parse(row.Item("keyValue")), 0)
+
+                'get speed digits
+                row = dtbl.Select("keyName = 'key06'").FirstOrDefault()
+                iSpeedDigits = If(row IsNot Nothing, Integer.Parse(row.Item("keyValue")), 0)
+            End If
+
+        Catch ex As Exception
+            MessageBox.Show("Error in getting direction and speed digits in the database . Error: " & ex.Message, "Digits", MessageBoxButtons.OK, MessageBoxIcon.Error)
+        End Try
+    End Sub
 End Class

--- a/ClimsoftVer4/ClimsoftVer4/ucrDirectionSpeedFlag.vb
+++ b/ClimsoftVer4/ClimsoftVer4/ucrDirectionSpeedFlag.vb
@@ -144,11 +144,11 @@ Public Class ucrDirectionSpeedFlag
         Return ucrFlag.IsEmpty()
     End Function
 
-    Public Sub SetElementDirectionValidation(iLowerLimit As Decimal, iUpperLimit As Decimal)
+    Public Sub SetElementDirectionValidation(Optional iLowerLimit As Decimal = Decimal.MinValue, Optional iUpperLimit As Decimal = Decimal.MaxValue)
         ucrDirection.SetValidationTypeAsNumeric(dcmMin:=iLowerLimit, dcmMax:=iUpperLimit)
     End Sub
 
-    Public Sub SetElementSpeedValidation(iLowerLimit As Decimal, iUpperLimit As Decimal)
+    Public Sub SetElementSpeedValidation(Optional iLowerLimit As Decimal = Decimal.MinValue, Optional iUpperLimit As Decimal = Decimal.MaxValue)
         ucrSpeed.SetValidationTypeAsNumeric(dcmMin:=iLowerLimit, dcmMax:=iUpperLimit)
     End Sub
 

--- a/ClimsoftVer4/ClimsoftVer4/ucrDirectionSpeedFlag.vb
+++ b/ClimsoftVer4/ClimsoftVer4/ucrDirectionSpeedFlag.vb
@@ -175,6 +175,10 @@ Public Class ucrDirectionSpeedFlag
         ucrSpeed.SetValidationTypeAsNumeric(dcmMin:=iLowerLimit, dcmMax:=iUpperLimit)
     End Sub
 
+    Public Function IsValuesValid() As Boolean
+
+    End Function
+
     Private Sub ucrDirectionSpeedFlag_KeyDown(sender As Object, e As KeyEventArgs) Handles ucrDDFF.evtKeyDown, ucrDirection.evtKeyDown, ucrSpeed.evtKeyDown, ucrFlag.evtKeyDown
         'TODO
         'FIND AWAY OF PASSING ME AND THE SENDER TO THE evtGoToNextVFPControl

--- a/ClimsoftVer4/ClimsoftVer4/ucrDirectionSpeedFlag.vb
+++ b/ClimsoftVer4/ClimsoftVer4/ucrDirectionSpeedFlag.vb
@@ -313,7 +313,7 @@ Public Class ucrDirectionSpeedFlag
                 ucrFlag.SetValue("")
             End If
 
-            'do QC for flag
+            'then do QC for flag
             bValuesCorrect = DoQcForFlag()
         End If
 

--- a/ClimsoftVer4/ClimsoftVer4/ucrDirectionSpeedFlag.vb
+++ b/ClimsoftVer4/ClimsoftVer4/ucrDirectionSpeedFlag.vb
@@ -94,37 +94,6 @@ Public Class ucrDirectionSpeedFlag
         End If
     End Sub
 
-    Public Function IsDirectionEmpty() As Boolean
-        Return ucrDirection.IsEmpty()
-    End Function
-
-    Public Function IsSpeedEmpty() As Boolean
-        Return ucrSpeed.IsEmpty()
-    End Function
-
-    Public Function IsFlagEmpty() As Boolean
-        Return ucrFlag.IsEmpty()
-    End Function
-
-    Public Function GetDirectionValue() As String
-        Return ucrDirection.GetValue
-    End Function
-
-    Public Function GetSpeedValue() As String
-        Return ucrDirection.GetValue
-    End Function
-
-    Public Function GetFlagValue() As String
-        Return ucrDirection.GetValue
-    End Function
-
-    Public Overrides Sub Clear()
-        ucrDDFF.Clear()
-        ucrDirection.Clear()
-        ucrSpeed.Clear()
-        ucrFlag.Clear()
-    End Sub
-
     Public Overrides Sub SetValue(objNewValue As Object)
         Dim lstValues As List(Of Object)
 
@@ -133,10 +102,87 @@ Public Class ucrDirectionSpeedFlag
         If lstValues.Count = 3 Then
             'ucrDDFF.SetValue(lstValues(0) + lstValues(1))
             ucrDDFF.SetValue("")
-            ucrDirection.SetValue(lstValues(0))
-            ucrSpeed.SetValue(lstValues(1))
-            ucrFlag.SetValue(lstValues(2))
+            SetElementDirectionValue(lstValues(0))
+            SetElementSpeedValue(lstValues(1))
+            SetElementFlagValue(lstValues(2))
         End If
+    End Sub
+
+    Public Sub SetElementDirectionValue(strValue As String)
+        ucrDirection.SetValue(strValue)
+    End Sub
+
+    Public Sub SetElementSpeedValue(strValue As String)
+        ucrSpeed.SetValue(strValue)
+    End Sub
+
+    Public Sub SetElementFlagValue(strValue As String)
+        ucrFlag.SetValue(strValue)
+    End Sub
+
+    Public Function GetElementDirectionValue() As String
+        Return ucrDirection.GetValue
+    End Function
+
+    Public Function GetElementSpeedValue() As String
+        Return ucrSpeed.GetValue
+    End Function
+
+    Public Function GetElementFlagValue() As String
+        Return ucrFlag.GetValue
+    End Function
+
+    Public Function IsElementDirectionEmpty() As Boolean
+        Return ucrDirection.IsEmpty()
+    End Function
+
+    Public Function IsElementSpeedEmpty() As Boolean
+        Return ucrSpeed.IsEmpty()
+    End Function
+
+    Public Function IsElementFlagEmpty() As Boolean
+        Return ucrFlag.IsEmpty()
+    End Function
+
+    Public Sub SetElementDirectionValidation(iLowerLimit As Decimal, iUpperLimit As Decimal)
+        ucrDirection.SetValidationTypeAsNumeric(dcmMin:=iLowerLimit, dcmMax:=iUpperLimit)
+    End Sub
+
+    Public Sub SetElementSpeedValidation(iLowerLimit As Decimal, iUpperLimit As Decimal)
+        ucrSpeed.SetValidationTypeAsNumeric(dcmMin:=iLowerLimit, dcmMax:=iUpperLimit)
+    End Sub
+
+    Public Sub SetDirectionDigits(iNewDirectionDigits As Integer)
+        iDirectionDigits = iNewDirectionDigits
+    End Sub
+
+    Public Sub SetSpeedDigits(iNewSpeedDigits As Integer)
+        iSpeedDigits = iNewSpeedDigits
+    End Sub
+
+    Public Function IsValuesValid() As Boolean
+        Return IsElementDirectionValueValid() AndAlso IsElementSpeedValueValid() AndAlso IsElementFlagValueValid()
+    End Function
+
+    Public Function IsElementDirectionValueValid() As Boolean
+        Return DoQcForDirection()
+    End Function
+
+    Public Function IsElementSpeedValueValid() As Boolean
+        Return DoQcForSpeed()
+    End Function
+
+    Public Function IsElementFlagValueValid() As Boolean
+        Return DoQcForFlag()
+    End Function
+
+
+
+    Public Overrides Sub Clear()
+        ucrDDFF.Clear()
+        ucrDirection.Clear()
+        ucrSpeed.Clear()
+        ucrFlag.Clear()
     End Sub
 
     Public Sub SetBackColor(backColor As Color)
@@ -159,27 +205,8 @@ Public Class ucrDirectionSpeedFlag
         End If
     End Sub
 
-    Public Sub SetDirectionDigits(iNewDirectionDigits As Integer)
-        iDirectionDigits = iNewDirectionDigits
-    End Sub
-
-    Public Sub SetSpeedDigits(iNewSpeedDigits As Integer)
-        iSpeedDigits = iNewSpeedDigits
-    End Sub
-
-    Public Sub SetDirectionValidation(iLowerLimit As Decimal, iUpperLimit As Decimal)
-        ucrDirection.SetValidationTypeAsNumeric(dcmMin:=iLowerLimit, dcmMax:=iUpperLimit)
-    End Sub
-
-    Public Sub SetSpeedValidation(iLowerLimit As Decimal, iUpperLimit As Decimal)
-        ucrSpeed.SetValidationTypeAsNumeric(dcmMin:=iLowerLimit, dcmMax:=iUpperLimit)
-    End Sub
-
-    Public Function IsValuesValid() As Boolean
-
-    End Function
-
-    Private Sub ucrDirectionSpeedFlag_KeyDown(sender As Object, e As KeyEventArgs) Handles ucrDDFF.evtKeyDown, ucrDirection.evtKeyDown, ucrSpeed.evtKeyDown, ucrFlag.evtKeyDown
+    'Todo remove flag event
+    Private Sub ucrDirectionSpeedFlag_KeyDown(sender As Object, e As KeyEventArgs) Handles ucrDDFF.evtKeyDown, ucrDirection.evtKeyDown, ucrSpeed.evtKeyDown
         'TODO
         'FIND AWAY OF PASSING ME AND THE SENDER TO THE evtGoToNextVFPControl
         'If {ENTER} key is pressed
@@ -204,30 +231,28 @@ Public Class ucrDirectionSpeedFlag
         Dim bValuesCorrect As Boolean = False
 
         If sender Is ucrDDFF.txtBox Then
-            If QCForUcrDDFF() Then
+            If DoQCForUcrDDFFUserInput() Then
                 bValuesCorrect = True
             End If
         ElseIf sender Is ucrDirection.txtBox Then
-            If QcForDirection() Then
+            If DoQcForDirection() Then
                 If Not ucrDirection.IsEmpty AndAlso ucrFlag.GetValue = "M" Then
                     ucrFlag.SetValue("")
                 End If
-                bValuesCorrect = True
+                bValuesCorrect = DoQcForFlag()
             End If
         ElseIf sender Is ucrSpeed.txtBox Then
-            If QcForSpeed() Then
+            If DoQcForSpeed() Then
                 If Not ucrSpeed.IsEmpty AndAlso ucrFlag.GetValue = "M" Then
                     ucrFlag.SetValue("")
                 End If
-                bValuesCorrect = True
+                bValuesCorrect = DoQcForFlag()
             End If
-        ElseIf sender Is ucrFlag.txtBox Then
-            bValuesCorrect = True
         End If
         Return bValuesCorrect
     End Function
 
-    Private Function QCForUcrDDFF() As Boolean
+    Private Function DoQCForUcrDDFFUserInput() As Boolean
         Dim bValuesCorrect As Boolean = False
         Dim bValidateSilently As Boolean
 
@@ -259,7 +284,7 @@ Public Class ucrDirectionSpeedFlag
                     ucrDirection.bValidateSilently = bValidateSilently
 
                     'proceed to do QC checks for direction and speed
-                    If QcForDirection() AndAlso QcForSpeed() Then
+                    If DoQcForDirection() AndAlso DoQcForSpeed() Then
                         ucrDDFF.SetBackColor(Color.White)
                         bValuesCorrect = True
                     Else
@@ -280,7 +305,6 @@ Public Class ucrDirectionSpeedFlag
             End If
         End If
 
-
         If bValuesCorrect Then
             'if values are empty then set flag as M else remove the M if its the currently set flag
             If ucrDDFF.IsEmpty AndAlso ucrDirection.IsEmpty AndAlso ucrSpeed.IsEmpty Then
@@ -290,51 +314,40 @@ Public Class ucrDirectionSpeedFlag
             End If
 
             'do QC for flag
-            bValuesCorrect = QcForFlag()
+            bValuesCorrect = DoQcForFlag()
         End If
 
         Return bValuesCorrect
     End Function
 
     'QC checks for  direction
-    Public Function QcForDirection() As Boolean
-        If ucrDirection.ValidateValue() Then
-            Return True
-        Else
-            ucrDirection.GetFocus()
-            Return False
-        End If
+    Private Function DoQcForDirection() As Boolean
+        'TODO. Should we check ucrDirection.GetValue.Length = iDirectionDigits ?
+        Return ucrDirection.ValidateValue()
     End Function
 
-    'QC checks for  wind
-    Public Function QcForSpeed() As Boolean
-        If ucrSpeed.ValidateValue() Then
-            Return True
-        Else
-            ucrSpeed.GetFocus()
-            Return False
-        End If
+    'QC checks for speed
+    Public Function DoQcForSpeed() As Boolean
+        'TODO. Should we check ucrSpeed.GetValue.Length = iSpeedDigits ?
+        Return ucrSpeed.ValidateValue()
     End Function
 
     'QC checks for flag
-    Public Function QcForFlag() As Boolean
+    Private Function DoQcForFlag() As Boolean
         Dim bValuesCorrect As Boolean = True
 
         'if value is empty then set flag as M else remove the M
         If ucrDirection.IsEmpty OrElse ucrSpeed.IsEmpty Then
-            If ucrFlag.GetValue = "M" Then
+            If ucrFlag.GetValue = "M" OrElse ucrFlag.IsEmpty Then
                 bValuesCorrect = True
             Else
                 MsgBox("M is the expected flag for a missing value", MsgBoxStyle.Critical)
                 ucrFlag.SetBackColor(Color.Cyan)
-                ucrFlag.GetFocus()
                 bValuesCorrect = False
             End If
         Else
             If ucrFlag.GetValue = "M" Then
-                'MsgBox("M is the expected flag for a missing value", MsgBoxStyle.Critical)
                 ucrFlag.SetBackColor(Color.Cyan)
-                ucrFlag.GetFocus()
                 bValuesCorrect = False
             Else
                 bValuesCorrect = True
@@ -343,7 +356,6 @@ Public Class ucrDirectionSpeedFlag
 
         Return bValuesCorrect
     End Function
-
 
     Private Sub ucrFlag_evtValueChanged(sender As Object, e As EventArgs) Handles ucrFlag.evtValueChanged
         'ucrFlag should is set as readonly. That changes its back color to the one given below

--- a/ClimsoftVer4/ClimsoftVer4/ucrHourlyWind.vb
+++ b/ClimsoftVer4/ClimsoftVer4/ucrHourlyWind.vb
@@ -187,14 +187,6 @@ Public Class ucrHourlyWind
                             ucrDSF.Enabled = False
                             ucrDSF.SetBackColor(Color.LightYellow)
                         End If
-                        'SIMILAR IMPLEMENTATION WOULD AS ABOVE WOULD BE AS COMMENTED BELOW
-                        'For Each rTemp As DataRow In dtbl.Rows
-                        '    If Val(rTemp("hh")) = iTagVal AndAlso Val(rTemp("hh_selection")) = 0 Then
-                        '        ucrDSF.enabled = False
-                        '        ucrDSF.SetBackColor(Color.LightYellow)
-                        '        Exit For
-                        '    End If
-                        'Next
                     End If
                 Next
             End If
@@ -363,7 +355,6 @@ Public Class ucrHourlyWind
     ''' <param name="ucrDayControl"></param>
     ''' <param name="ucrNavigationControl"></param>
     Public Sub SetKeyControls(ucrStationControl As ucrStationSelector, ucrYearControl As ucrYearSelector, ucrMonthControl As ucrMonth, ucrDayControl As ucrDay, ucrNavigationControl As ucrNavigation)
-
         ucrLinkedStation = ucrStationControl
         ucrLinkedYear = ucrYearControl
         ucrLinkedMonth = ucrMonthControl
@@ -380,8 +371,6 @@ Public Class ucrHourlyWind
         ucrLinkedNavigation.SetKeyControls("yyyy", ucrLinkedYear)
         ucrLinkedNavigation.SetKeyControls("mm", ucrLinkedMonth)
         ucrLinkedNavigation.SetKeyControls("dd", ucrLinkedDay)
-
-
     End Sub
 
     ''' <summary>

--- a/ClimsoftVer4/ClimsoftVer4/ucrHourlyWind.vb
+++ b/ClimsoftVer4/ClimsoftVer4/ucrHourlyWind.vb
@@ -321,6 +321,7 @@ Public Class ucrHourlyWind
 
     ''' <summary>
     ''' will check the expected total if its indicated as required in the obselements table
+    ''' returns true if the expected total speed value = computed total speed value or when the speed total is not required
     ''' </summary>
     ''' <returns></returns>
     Public Function checkSpeedTotal() As Boolean
@@ -329,10 +330,8 @@ Public Class ucrHourlyWind
         Dim expectedTotal As Integer
 
         If iSpeedTotalRequired = 1 Then
-
             If ucrInputTotal.IsEmpty AndAlso Not IsSpeedValuesEmpty() Then
                 MessageBox.Show("Please enter the Total Value in the (Total [ff]) textbox.", "Error in total", MessageBoxButtons.OK, MessageBoxIcon.Error)
-                'ucrInputTotal.GetFocus()
                 ucrInputTotal.SetBackColor(Color.Cyan)
                 bValueCorrect = False
             Else
@@ -345,7 +344,6 @@ Public Class ucrHourlyWind
                 bValueCorrect = (elemTotal = expectedTotal)
                 If Not bValueCorrect Then
                     MessageBox.Show("Value in [Total] textbox is different from that calculated by computer! The computed total is " & elemTotal, "Error in total", MessageBoxButtons.OK, MessageBoxIcon.Error)
-                    'ucrInputTotal.GetFocus()
                     ucrInputTotal.SetBackColor(Color.Cyan)
                 End If
             End If

--- a/ClimsoftVer4/ClimsoftVer4/ucrHourlyWind.vb
+++ b/ClimsoftVer4/ClimsoftVer4/ucrHourlyWind.vb
@@ -277,11 +277,29 @@ Public Class ucrHourlyWind
         Return True
     End Function
 
+
     ''' <summary>
     ''' returns true if all direction values are valid
     ''' </summary>
     ''' <returns></returns>
-    Public Function CheckQcForDirection() As Boolean
+    Public Function IsValuesValid() As Boolean
+        'For Each ctr As Control In Me.Controls
+        '    If TypeOf ctr Is ucrDirectionSpeedFlag Then
+        '        'TODO
+        '        If Not DirectCast(ctr, ucrDirectionSpeedFlag).IsValuesValid() Then
+        '            Return False
+        '        End If
+        '    End If
+        'Next
+        Return CheckQcForDirection() AndAlso CheckQcForSpeed()
+    End Function
+
+    ''' <summary>
+    ''' TODO. this will be removed later
+    ''' returns true if all direction values are valid
+    ''' </summary>
+    ''' <returns></returns>
+    Private Function CheckQcForDirection() As Boolean
         For Each ctr As Control In Me.Controls
             If TypeOf ctr Is ucrDirectionSpeedFlag Then
                 If Not DirectCast(ctr, ucrDirectionSpeedFlag).QcForDirection() Then
@@ -293,10 +311,11 @@ Public Class ucrHourlyWind
     End Function
 
     ''' <summary>
-    ''' returns true if all the speed values are bvalid
+    ''' TODO. this will be removed later
+    ''' returns true if all the speed values are valid
     ''' </summary>
     ''' <returns></returns>
-    Public Function CheckQcForSpeed() As Boolean
+    Private Function CheckQcForSpeed() As Boolean
         For Each ctr As Control In Me.Controls
             If TypeOf ctr Is ucrDirectionSpeedFlag Then
                 If Not DirectCast(ctr, ucrDirectionSpeedFlag).QcForSpeed() Then
@@ -335,7 +354,7 @@ Public Class ucrHourlyWind
                 Next
                 bValueCorrect = (elemTotal = expectedTotal)
                 If Not bValueCorrect Then
-                    MessageBox.Show("Value in [Total] textbox is different from that calculated by computer! The computed total is " & elemTotal, "Error in total", MessageBoxButtons.OK, MessageBoxIcon.Error)
+                    MessageBox.Show("Value in (Total [ff]) textbox is different from that calculated by computer! The computed total is " & elemTotal, "Error in total", MessageBoxButtons.OK, MessageBoxIcon.Error)
                     ucrInputTotal.SetBackColor(Color.Cyan)
                 End If
             End If
@@ -388,7 +407,7 @@ Public Class ucrHourlyWind
 
         'initialise the dates with ONLY year month and day values. 
         'Neglect the time factor
-        todayDate = New Date(DateTime.Now.Year, DateTime.Now.Month, DateTime.Now.Day)
+        todayDate = New Date(Date.Now.Year, Date.Now.Month, Date.Now.Day)
         selectedDate = New Date(ucrLinkedYear.GetValue, ucrLinkedMonth.GetValue, ucrLinkedDay.GetValue)
 
         'if selectedDate is earlier than todayDate enable control

--- a/ClimsoftVer4/ClimsoftVer4/ucrHourlyWind.vb
+++ b/ClimsoftVer4/ClimsoftVer4/ucrHourlyWind.vb
@@ -222,7 +222,7 @@ Public Class ucrHourlyWind
         If dtbl IsNot Nothing AndAlso dtbl.Rows.Count > 0 Then
             For Each ctr As Control In Me.Controls
                 If TypeOf ctr Is ucrDirectionSpeedFlag Then
-                    DirectCast(ctr, ucrDirectionSpeedFlag).SetDirectionValidation(Val(dtbl.Rows(0).Item("lowerLimit")), Val(dtbl.Rows(0).Item("upperLimit")))
+                    DirectCast(ctr, ucrDirectionSpeedFlag).SetElementDirectionValidation(Val(dtbl.Rows(0).Item("lowerLimit")), Val(dtbl.Rows(0).Item("upperLimit")))
                 End If
             Next
         End If
@@ -241,7 +241,7 @@ Public Class ucrHourlyWind
         If dtbl IsNot Nothing AndAlso dtbl.Rows.Count > 0 Then
             For Each ctr As Control In Me.Controls
                 If TypeOf ctr Is ucrDirectionSpeedFlag Then
-                    DirectCast(ctr, ucrDirectionSpeedFlag).SetSpeedValidation(Val(dtbl.Rows(0).Item("lowerLimit")), Val(dtbl.Rows(0).Item("upperLimit")))
+                    DirectCast(ctr, ucrDirectionSpeedFlag).SetElementSpeedValidation(Val(dtbl.Rows(0).Item("lowerLimit")), Val(dtbl.Rows(0).Item("upperLimit")))
                 End If
             Next
             iSpeedTotalRequired = Val(dtbl.Rows(0).Item("QCTotalRequired"))
@@ -254,7 +254,7 @@ Public Class ucrHourlyWind
     Public Function IsDirectionValuesEmpty() As Boolean
         For Each ctr As Control In Me.Controls
             If TypeOf ctr Is ucrDirectionSpeedFlag Then
-                If Not DirectCast(ctr, ucrDirectionSpeedFlag).IsDirectionEmpty() Then
+                If Not DirectCast(ctr, ucrDirectionSpeedFlag).IsElementDirectionEmpty() Then
                     Return False
                 End If
             End If
@@ -269,7 +269,7 @@ Public Class ucrHourlyWind
     Public Function IsSpeedValuesEmpty() As Boolean
         For Each ctr As Control In Me.Controls
             If TypeOf ctr Is ucrDirectionSpeedFlag Then
-                If Not DirectCast(ctr, ucrDirectionSpeedFlag).IsSpeedEmpty Then
+                If Not DirectCast(ctr, ucrDirectionSpeedFlag).IsElementSpeedEmpty Then
                     Return False
                 End If
             End If
@@ -279,30 +279,23 @@ Public Class ucrHourlyWind
 
 
     ''' <summary>
-    ''' returns true if all direction values are valid
+    ''' returns true if all direction values are valid and false if any of them is not valid
     ''' </summary>
     ''' <returns></returns>
     Public Function IsValuesValid() As Boolean
-        'For Each ctr As Control In Me.Controls
-        '    If TypeOf ctr Is ucrDirectionSpeedFlag Then
-        '        'TODO
-        '        If Not DirectCast(ctr, ucrDirectionSpeedFlag).IsValuesValid() Then
-        '            Return False
-        '        End If
-        '    End If
-        'Next
-        Return CheckQcForDirection() AndAlso CheckQcForSpeed()
-    End Function
-
-    ''' <summary>
-    ''' TODO. this will be removed later
-    ''' returns true if all direction values are valid
-    ''' </summary>
-    ''' <returns></returns>
-    Private Function CheckQcForDirection() As Boolean
+        Dim ucrDSF As ucrDirectionSpeedFlag
         For Each ctr As Control In Me.Controls
             If TypeOf ctr Is ucrDirectionSpeedFlag Then
-                If Not DirectCast(ctr, ucrDirectionSpeedFlag).QcForDirection() Then
+                ucrDSF = DirectCast(ctr, ucrDirectionSpeedFlag)
+                If Not ucrDSF.IsElementDirectionValueValid Then
+                    ucrDSF.ucrDirection.GetFocus()
+                    Return False
+                ElseIf Not ucrDSF.IsElementSpeedValueValid
+                    ucrDSF.ucrSpeed.GetFocus()
+                    Return False
+                ElseIf Not ucrDSF.IsElementFlagValueValid
+                    'because Flag is read only
+                    ucrDSF.Focus()
                     Return False
                 End If
             End If
@@ -310,23 +303,7 @@ Public Class ucrHourlyWind
         Return True
     End Function
 
-    ''' <summary>
-    ''' TODO. this will be removed later
-    ''' returns true if all the speed values are valid
-    ''' </summary>
-    ''' <returns></returns>
-    Private Function CheckQcForSpeed() As Boolean
-        For Each ctr As Control In Me.Controls
-            If TypeOf ctr Is ucrDirectionSpeedFlag Then
-                If Not DirectCast(ctr, ucrDirectionSpeedFlag).QcForSpeed() Then
-                    Return False
-                End If
-            End If
-        Next
-        Return True
-    End Function
-
-    Private Sub ucrInputTotal_evtValueChanged(sender As Object, e As EventArgs) Handles ucrInputTotal.evtValueChanged
+    Private Sub ucrInputTotal_Leave(sender As Object, e As EventArgs) Handles ucrInputTotal.Leave
         checkSpeedTotal()
     End Sub
 
@@ -349,7 +326,7 @@ Public Class ucrHourlyWind
                 expectedTotal = Val(ucrInputTotal.GetValue)
                 For Each ctr As Control In Me.Controls
                     If TypeOf ctr Is ucrDirectionSpeedFlag Then
-                        elemTotal = elemTotal + Val(DirectCast(ctr, ucrDirectionSpeedFlag).GetSpeedValue)
+                        elemTotal = elemTotal + Val(DirectCast(ctr, ucrDirectionSpeedFlag).GetElementSpeedValue)
                     End If
                 Next
                 bValueCorrect = (elemTotal = expectedTotal)

--- a/ClimsoftVer4/ClimsoftVer4/ucrHourlyWind.vb
+++ b/ClimsoftVer4/ClimsoftVer4/ucrHourlyWind.vb
@@ -7,7 +7,7 @@ Public Class ucrHourlyWind
     Private strSpeedFieldName As String = "elem_111_"
     Private strFlagFieldName As String = "ddflag"
     Private strTotalFieldName As String = "total"
-    Private iSpeedTotalRequired As Integer
+    Private bSpeedTotalRequired As Boolean
     Private bSelectAllHours As Boolean
     Private lstFields As New List(Of String)
     Public fhourlyWindRecord As form_hourlywind
@@ -210,6 +210,7 @@ Public Class ucrHourlyWind
     End Sub
 
     Public Sub SetDirectionValidation(elementId As Integer)
+        Dim ucrDSF As ucrDirectionSpeedFlag
         Dim clsDataDefinition As DataCall
         Dim dtbl As DataTable
         clsDataDefinition = New DataCall
@@ -222,29 +223,42 @@ Public Class ucrHourlyWind
         If dtbl IsNot Nothing AndAlso dtbl.Rows.Count > 0 Then
             For Each ctr As Control In Me.Controls
                 If TypeOf ctr Is ucrDirectionSpeedFlag Then
-                    DirectCast(ctr, ucrDirectionSpeedFlag).SetElementDirectionValidation(Val(dtbl.Rows(0).Item("lowerLimit")), Val(dtbl.Rows(0).Item("upperLimit")))
+                    ucrDSF = ctr
+                    If dtbl.Rows(0).Item("lowerLimit") <> "" Then
+                        ucrDSF.SetElementDirectionValidation(iLowerLimit:=Val(dtbl.Rows(0).Item("lowerLimit")))
+                    End If
+                    If dtbl.Rows(0).Item("upperLimit") <> "" Then
+                        ucrDSF.SetElementDirectionValidation(iUpperLimit:=Val(dtbl.Rows(0).Item("upperLimit")))
+                    End If
                 End If
             Next
         End If
     End Sub
 
     Public Sub SetSpeedValidation(elementId As Integer)
+        Dim ucrDSF As ucrDirectionSpeedFlag
         Dim clsDataDefinition As DataCall
         Dim dtbl As DataTable
         clsDataDefinition = New DataCall
         'PLEASE NOTE THIS TABLE IS CALLED obselement IN THE DATABASE BUT
         'THE GENERATED ENTITY MODEL HAS NAMED IT AS obselements
         clsDataDefinition.SetTableName("obselements")
-        clsDataDefinition.SetFields(New List(Of String)({"lowerLimit", "upperLimit", "QCTotalRequired"}))
+        clsDataDefinition.SetFields(New List(Of String)({"lowerLimit", "upperLimit", "qcTotalRequired"}))
         clsDataDefinition.SetFilter("elementId", "=", elementId, bForceValuesAsString:=False)
         dtbl = clsDataDefinition.GetDataTable()
         If dtbl IsNot Nothing AndAlso dtbl.Rows.Count > 0 Then
             For Each ctr As Control In Me.Controls
                 If TypeOf ctr Is ucrDirectionSpeedFlag Then
-                    DirectCast(ctr, ucrDirectionSpeedFlag).SetElementSpeedValidation(Val(dtbl.Rows(0).Item("lowerLimit")), Val(dtbl.Rows(0).Item("upperLimit")))
+                    ucrDSF = ctr
+                    If dtbl.Rows(0).Item("lowerLimit") <> "" Then
+                        ucrDSF.SetElementSpeedValidation(iLowerLimit:=Val(dtbl.Rows(0).Item("lowerLimit")))
+                    End If
+                    If dtbl.Rows(0).Item("upperLimit") <> "" Then
+                        ucrDSF.SetElementSpeedValidation(iUpperLimit:=Val(dtbl.Rows(0).Item("upperLimit")))
+                    End If
                 End If
             Next
-            iSpeedTotalRequired = Val(dtbl.Rows(0).Item("QCTotalRequired"))
+            bSpeedTotalRequired = If(dtbl.Rows(0).Item("qcTotalRequired") <> "" AndAlso Val(dtbl.Rows(0).Item("qcTotalRequired") <> 0), True, False)
         End If
     End Sub
     ''' <summary>
@@ -317,7 +331,7 @@ Public Class ucrHourlyWind
         Dim elemTotal As Integer = 0
         Dim expectedTotal As Integer
 
-        If iSpeedTotalRequired = 1 Then
+        If bSpeedTotalRequired Then
             If ucrInputTotal.IsEmpty AndAlso Not IsSpeedValuesEmpty() Then
                 MessageBox.Show("Please enter the Total Value in the (Total [ff]) textbox.", "Error in total", MessageBoxButtons.OK, MessageBoxIcon.Error)
                 ucrInputTotal.SetBackColor(Color.Cyan)

--- a/ClimsoftVer4/ClimsoftVer4/ucrHourlyWind.vb
+++ b/ClimsoftVer4/ClimsoftVer4/ucrHourlyWind.vb
@@ -260,11 +260,24 @@ Public Class ucrHourlyWind
     ''' </summary>
     ''' <returns></returns>
     Public Function IsDirectionValuesEmpty() As Boolean
-        Dim ucrDSF As ucrDirectionSpeedFlag
         For Each ctr As Control In Me.Controls
             If TypeOf ctr Is ucrDirectionSpeedFlag Then
-                ucrDSF = ctr
-                If Not ucrDSF.IsDirectionEmpty() Then
+                If Not DirectCast(ctr, ucrDirectionSpeedFlag).IsDirectionEmpty() Then
+                    Return False
+                End If
+            End If
+        Next
+        Return True
+    End Function
+
+    ''' <summary>
+    ''' Returns true if all the speed values are empty and false if ANY has a value set
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function IsSpeedValuesEmpty() As Boolean
+        For Each ctr As Control In Me.Controls
+            If TypeOf ctr Is ucrDirectionSpeedFlag Then
+                If Not DirectCast(ctr, ucrDirectionSpeedFlag).IsSpeedEmpty Then
                     Return False
                 End If
             End If
@@ -302,35 +315,45 @@ Public Class ucrHourlyWind
         Return True
     End Function
 
-    Private Sub ucrInputTotal_Leave(sender As Object, e As EventArgs) Handles ucrInputTotal.Leave
-        checkTotal()
+    Private Sub ucrInputTotal_evtValueChanged(sender As Object, e As EventArgs) Handles ucrInputTotal.evtValueChanged
+        checkSpeedTotal()
     End Sub
 
-    Public Function checkTotal() As Boolean
+    ''' <summary>
+    ''' will check the expected total if its indicated as required in the obselements table
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function checkSpeedTotal() As Boolean
+        Dim bValueCorrect As Boolean = False
         Dim elemTotal As Integer = 0
         Dim expectedTotal As Integer
 
         If iSpeedTotalRequired = 1 Then
 
-            expectedTotal = Val(ucrInputTotal.GetValue)
-
-            For Each ctr As Control In Me.Controls
-                If TypeOf ctr Is ucrDirectionSpeedFlag Then
-                    elemTotal = elemTotal + Val(DirectCast(ctr, ucrDirectionSpeedFlag).GetFlagValue)
-                End If
-            Next
-
-            If elemTotal = expectedTotal Then
-                Return True
-            Else
-                MessageBox.Show("Value in [Total] textbox is different from that calculated by computer!", "Error in total", MessageBoxButtons.OK, MessageBoxIcon.Error)
-                ucrInputTotal.GetFocus()
+            If ucrInputTotal.IsEmpty AndAlso Not IsSpeedValuesEmpty() Then
+                MessageBox.Show("Please enter the Total Value in the (Total [ff]) textbox.", "Error in total", MessageBoxButtons.OK, MessageBoxIcon.Error)
+                'ucrInputTotal.GetFocus()
                 ucrInputTotal.SetBackColor(Color.Cyan)
-                Return False
+                bValueCorrect = False
+            Else
+                expectedTotal = Val(ucrInputTotal.GetValue)
+                For Each ctr As Control In Me.Controls
+                    If TypeOf ctr Is ucrDirectionSpeedFlag Then
+                        elemTotal = elemTotal + Val(DirectCast(ctr, ucrDirectionSpeedFlag).GetSpeedValue)
+                    End If
+                Next
+                bValueCorrect = (elemTotal = expectedTotal)
+                If Not bValueCorrect Then
+                    MessageBox.Show("Value in [Total] textbox is different from that calculated by computer! The computed total is " & elemTotal, "Error in total", MessageBoxButtons.OK, MessageBoxIcon.Error)
+                    'ucrInputTotal.GetFocus()
+                    ucrInputTotal.SetBackColor(Color.Cyan)
+                End If
             End If
         Else
-            Return True
+            bValueCorrect = True
         End If
+
+        Return bValueCorrect
     End Function
 
     ''' <summary>


### PR DESCRIPTION
Fixes partly issue #76
@africanmathsinitiative/developers this is ready for review.
The values that control whether the speed total is required or not are located in the table obselement, elementId 111, column named qcTotalRequired. In that column, 1 means required, 0 means not required. 
@maxwellfundi I'm not quite sure the feedback to give when the total is not entered.