### PR TITLE
UcrFlag Valid Back Color

### DIFF
--- a/ClimsoftVer4/ClimsoftVer4/ucrValueFlagPeriod.vb
+++ b/ClimsoftVer4/ClimsoftVer4/ucrValueFlagPeriod.vb
@@ -227,6 +227,8 @@ Public Class ucrValueFlagPeriod
             ucrValue.SetValidationTypeAsNumeric()
             ucrFlag.SetTextToUpper()
             ucrFlag.SetAsReadOnly()
+            'ucrFlag being a readonly. This makes its back color to be just like that of readonly when it has a valid value
+            ucrFlag.SetValidColor(SystemColors.Control)
             SetTextBoxSize()
             bFirstLoad = False
         End If
@@ -346,14 +348,6 @@ Public Class ucrValueFlagPeriod
         ucrValue.SetElementValueSize(New Size(51, 20))
         ucrFlag.SetElementValueSize(New Size(27, 20))
         ucrPeriod.SetElementValueSize(New Size(33, 20))
-    End Sub
-
-    'This is temporary
-    Private Sub ucrFlag_evtValueChanged(sender As Object, e As EventArgs) Handles ucrFlag.evtValueChanged
-        'ucrFlag should is set as readonly. That changes its back color to the one given below
-        'for consistency we are rienforcing this color everytime a value is changed on this control
-        'to override the white color being set on textbox validation subroutine
-        ucrFlag.SetBackColor(SystemColors.Control)
     End Sub
 
 End Class

--- a/ClimsoftVer4/ClimsoftVer4/ucrValueFlagPeriod.vb
+++ b/ClimsoftVer4/ClimsoftVer4/ucrValueFlagPeriod.vb
@@ -241,7 +241,7 @@ Public Class ucrValueFlagPeriod
                 If ucrValue.IsEmpty Then
                     ucrFlag.SetValue("M")
                     RaiseEvent evtGoToNextVFPControl(Me, e)
-                ElseIf PreValidateValue() Then
+                ElseIf ValidateText(ucrValue.GetValue) Then
                     RaiseEvent evtGoToNextVFPControl(Me, e)
                 ElseIf ucrValue.GetValue = "M"
                     RaiseEvent evtGoToNextVFPControl(Me, e)
@@ -318,12 +318,12 @@ Public Class ucrValueFlagPeriod
 
     ''' <summary>
     ''' checks if the value input in the ucrValue will be a valid value or not 
-    ''' when Quality Control is applied to the input.
+    ''' when Quality Control is applied to the passed value.
     ''' </summary>
     ''' <returns></returns>
-    Public Function PreValidateValue() As Boolean
+    Public Function ValidateText(strNewValue As String) As Boolean
         Dim bValuesCorrect As Boolean = False
-        Dim strValue As String = ucrValue.GetValue
+        Dim strValue As String = strNewValue
 
         If strValue = "" Then
             bValuesCorrect = True


### PR DESCRIPTION
@africanmathsinitiative/developers this is ready for review.
Makes the back color of `ucrFlag `to be similar to read only, Giving it the standard read only back color for vb.net readonly textboxes