### PR TITLE
ucrDirection, ucrSpeed, ucrFlag Valid Back Color

### DIFF
--- a/ClimsoftVer4/ClimsoftVer4/ucrDirectionSpeedFlag.vb
+++ b/ClimsoftVer4/ClimsoftVer4/ucrDirectionSpeedFlag.vb
@@ -215,15 +215,18 @@ Public Class ucrDirectionSpeedFlag
             ucrDirection.bValidateSilently = True
             ucrDirection.SetValidationTypeAsNumeric()
             ucrDirection.SetAsReadOnly()
-            ucrDirection.SetBackColor(Color.White)
+            'ucrDirection being a readonly. Makes back color to be like that of readonly when it has a valid value
+            ucrDirection.SetValidColor(SystemColors.Control)
 
             ucrSpeed.bValidateSilently = True
             ucrSpeed.SetValidationTypeAsNumeric()
             ucrSpeed.SetAsReadOnly()
-            ucrSpeed.SetBackColor(Color.White)
+            ucrSpeed.SetValidColor(SystemColors.Control)
 
             ucrFlag.SetTextToUpper()
             ucrFlag.SetAsReadOnly()
+            ucrFlag.SetValidColor(SystemColors.Control)
+
             bFirstLoad = False
         End If
     End Sub
@@ -357,14 +360,6 @@ Public Class ucrDirectionSpeedFlag
         End If
         Return bValuesCorrect
     End Function
-
-    'TODO. This is temporary. To be changed once the textbox valid color property has been added
-    Private Sub ucrFlag_evtValueChanged(sender As Object, e As EventArgs) Handles ucrFlag.evtValueChanged
-        'ucrFlag should is set as readonly. That changes its back color to the one given below
-        'for consistency we are rienforcing this color everytime a value is changed on this control
-        'to override the white color being set on textbox validation subroutine
-        ucrFlag.SetBackColor(SystemColors.Control)
-    End Sub
 
 End Class
 

--- a/ClimsoftVer4/ClimsoftVer4/ucrDirectionSpeedFlag.vb
+++ b/ClimsoftVer4/ClimsoftVer4/ucrDirectionSpeedFlag.vb
@@ -239,7 +239,7 @@ Public Class ucrDirectionSpeedFlag
                 If ucrDDFF.IsEmpty Then
                     ucrFlag.SetValue("M")
                     RaiseEvent evtGoToNextDSFControl(Me, e)
-                ElseIf PreValidateValue() Then
+                ElseIf ValidateText(ucrDDFF.GetValue) Then
                     RaiseEvent evtGoToNextDSFControl(Me, e)
                 ElseIf ucrDDFF.GetValue = "M"
                     RaiseEvent evtGoToNextDSFControl(Me, e)
@@ -338,13 +338,13 @@ Public Class ucrDirectionSpeedFlag
 
     ''' <summary>
     ''' checks if the value of the DD and FF input in the ucrDDFF will be a valid value or not 
-    ''' when Quality Control is applied to the input
+    ''' when Quality Control is applied to the passed value
     ''' </summary>
     ''' <returns></returns>
-    Public Function PreValidateValue() As Boolean
+    Public Function ValidateText(strNewVal As String) As Boolean
         Dim bValuesCorrect As Boolean = False
-        Dim strVal As String
-        strVal = ucrDDFF.GetValue
+        Dim strVal As String = strNewVal
+
         If strVal = "" Then
             bValuesCorrect = True
         Else


### PR DESCRIPTION
@africanmathsinitiative/developers this is ready for review.
The above three controls are supposed to be read only. Changes makes their valid color be similar to the standard readonly back color for textboxes